### PR TITLE
Optional Minor Edit by Default

### DIFF
--- a/action.php
+++ b/action.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * DokuWiki Action component of EnforceSummary Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author  Matthias Schulte <dokuwiki@lupo49.de>
+ * @author  Sahara Satoshi <sahara.satoshi@gmail.com>
+ */
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'action.php');
+
+/**
+ * All DokuWiki plugins to interfere with the event system
+ * need to inherit from this class
+ */
+class action_plugin_enforcesummary extends DokuWiki_Action_Plugin {
+
+    // register hook
+    function register(&$controller) {
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, '_exportToJSINFO');
+    }
+
+    /**
+     * Exports configuration settings to $JSINFO
+     */
+    function _exportToJSINFO(&$event) {
+
+        global $JSINFO;
+
+        $JSINFO['plugin_enforcesummary'] = array(
+                'default_minoredit'   => $this->GetConf('default_minoredit'),
+            );
+    }
+}

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * EnforceSummary plugin, default configuration settings
+ *
+ */
+
+$conf['default_minoredit'] = false;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * EnforceSummary plugin, configuration metadata
+ *
+ */
+
+$meta['default_minoredit'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * English language file for EnforceSummary Plugin
+ * used in the configuration manager
+ */
+
+$lang['default_minoredit'] = "Enable Minor Edit by default";

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Japanese language file for EnforceSummary Plugin
+ * used in the configuration manager
+ */
+
+$lang['default_minoredit'] = "小変更をデフォルトで有効にする";

--- a/script.js
+++ b/script.js
@@ -8,6 +8,12 @@ jQuery(function() {
     var $summary = jQuery('#edit__summary'); // get summary field
     var $minoredit = jQuery('#minoredit');
 
+    // Minor Edit by default
+    // Parts copied from https://www.dokuwiki.org/tips:autominor
+    var prv = jQuery('div.preview');
+    if (!prv[0] && JSINFO.plugin_enforcesummary.default_minoredit)
+        jQuery('#minoredit').prop('checked', true);
+
     // Parts copied from https://www.dokuwiki.org/tips:summary_enforcement
     $summary.keyup(enforceSummary).focus(enforceSummary);
     $minoredit.change(enforceSummary);


### PR DESCRIPTION
The concept of this request is to add "Default Minor Edit" option that the admin can set in the Configuration Manager.
This means that EnforceSummary plugin implements both tips of [Summary Enforcement](https://www.dokuwiki.org/tips:summary_enforcement) and [Auto Minor](https://www.dokuwiki.org/tips:autominor).

We make an annual release of a set of pages following several small edits continue by next major release. Summary enforcement is useful for such small edits to know what changed in the page. Auto Minor might be convenient for intensive update period that users frequently update pages prior to official release. Therefore I merged both into EnforceSummary plugin with Auto Minor option default off. 
