### PR TITLE
support new FORM_EDIT_OUTPUT event

### DIFF
--- a/action.php
+++ b/action.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DokuWiki Action component of EnforceSummary Plugin
  *
@@ -6,42 +7,34 @@
  * @author  Matthias Schulte <dokuwiki@lupo49.de>
  * @author  Sahara Satoshi <sahara.satoshi@gmail.com>
  */
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'action.php');
-
-/**
- * All DokuWiki plugins to interfere with the event system
- * need to inherit from this class
- */
-class action_plugin_enforcesummary extends DokuWiki_Action_Plugin {
-
+class action_plugin_enforcesummary extends DokuWiki_Action_Plugin
+{
     // register hook
-    function register(Doku_Event_Handler $controller) {
-        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, '_exportToJSINFO');
-        $controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, '_append_edit_guide');
+    public function register(Doku_Event_Handler $controller)
+    {
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'exportToJSINFO');
+        $controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'appendEditGuide');
     }
 
     /**
      * Exports configuration settings to $JSINFO
      */
-    function _exportToJSINFO(&$event) {
-
+    public function exportToJSINFO(Doku_Event $event)
+    {
         global $JSINFO;
 
         $JSINFO['plugin_enforcesummary'] = array(
                 'enforce_summary'    => $this->getConf('enforce_summary'),
                 'default_minoredit'  => $this->getConf('default_minoredit'),
                 'enforce_preview'    => $this->getConf('enforce_preview'),
-            );
+        );
     }
 
     /**
      * Append Edit Guide in the Edit Window (below save button)
      */
-    function _append_edit_guide(&$event) {
+    public function appendEditGuide(Doku_Event $event)
+    {
         $pos = $event->data->findElementByAttribute('class', 'editButtons');
         if (!$pos) return; // no editButtons
         $guidance = $this->locale_xhtml('edit_guide');

--- a/action.php
+++ b/action.php
@@ -13,6 +13,7 @@ class action_plugin_enforcesummary extends DokuWiki_Action_Plugin
     public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'exportToJSINFO');
+        $controller->register_hook('FORM_EDIT_OUTPUT', 'BEFORE', $this, 'appendEditGuide');
         $controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'appendEditGuide');
     }
 
@@ -35,10 +36,21 @@ class action_plugin_enforcesummary extends DokuWiki_Action_Plugin
      */
     public function appendEditGuide(Doku_Event $event)
     {
-        $pos = $event->data->findElementByAttribute('class', 'editButtons');
-        if (!$pos) return; // no editButtons
         $guidance = $this->locale_xhtml('edit_guide');
         $html = '<div id="plugin_enforcesummary_wrapper">'.$guidance.'</div>';
-        $event->data->addElement($html);
+
+        $form =& $event->data;
+        if (($event->name == 'FORM_EDIT_OUTPUT')
+            && (($pos = $form->findPositionByAttribute('id', 'edit__minoredit')) !== false)
+        ) {
+            // applicable to development snapshot 2020-10-13 or later
+            // insert the edit guide after minor edit checkbox
+            $form->addHTML($html, ++$pos);
+
+        } elseif ($event->name == 'HTML_EDITFORM_OUTPUT') {
+            $pos = $form->findElementByAttribute('class', 'editButtons');
+            if (!$pos) return; // no editButtons
+            $form->addElement($html);
+        }
     }
 }

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,6 +2,6 @@ base   enforcesummary
 author Matthias Schulte
 email  dokuwiki@lupo49.de
 date   2014-02-09
-name   enforcesummary plugin
+name   EnforceSummary plugin
 desc   Enforce summary or minor change on all edits
-url    http://www.dokuwiki.org/plugin:enforcesummary
+url    https://www.dokuwiki.org/plugin:enforcesummary

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 /*
  enforcesummary plugin for DokuWiki
  File: script.js
- http://www.dokuwiki.org/plugin:enforcesummary
+ https://www.dokuwiki.org/plugin:enforcesummary
  */
 
 jQuery(function() {
@@ -10,10 +10,13 @@ jQuery(function() {
 
     // Minor Edit by default
     // Parts copied from https://www.dokuwiki.org/tips:autominor
-    var $minoredit = jQuery('#minoredit');
+    // Note: since DokuWiki 2020-10-13 snapshot, the id of minoredit checkbox
+    //       has changed to "edit__minoredit" from "minoredit".
+    //       We must find '#edit__minoredit" or '#minoredit' for compatibility.
+    var $minoredit = jQuery('#edit__minoredit,#minoredit');
     var prv = jQuery('div.preview');
     if (!prv[0] && JSINFO.plugin_enforcesummary.default_minoredit)
-        jQuery('#minoredit').prop('checked', true);
+        jQuery('#edit__minoredit,#minoredit').prop('checked', true);
 
     // Parts copied from https://www.dokuwiki.org/tips:summary_enforcement
     $summary.keyup(enforceSummary).focus(enforceSummary);
@@ -23,16 +26,16 @@ jQuery(function() {
 
 function enforceSummary() {
     var $summary = jQuery('#edit__summary'); // get summary field
-    var $minoredit = jQuery('#minoredit');
-    var ckgd =  jQuery( "input[type=checkbox][name=ckgdoku]:checked" ).val();
-    var ckge =  jQuery( "input[type=checkbox][name=ckgedit]:checked" ).val();
+    var $minoredit = jQuery('#edit__minoredit,#minoredit');
+    var ckgd =  jQuery( 'input[type="checkbox"][name="ckgdoku"]:checked' ).val();
+    var ckge =  jQuery( 'input[type="checkbox"][name="ckgedit"]:checked' ).val();
     var m_class, $savebutton;
-    if(typeof ckgd == 'string' || typeof ckge == 'string') {       
-        $savebutton = jQuery("#save_button");
-        m_class = "plugin_enforcesummary_missing";
+    if (typeof ckgd == 'string' || typeof ckge == 'string') {
+        $savebutton = jQuery('#save_button');
+        m_class = 'plugin_enforcesummary_missing';
     } else {
-        $savebutton = jQuery("#edbtn__save");
-        m_class = "missing"
+        $savebutton = jQuery('#edbtn__save');
+        m_class = 'missing'
         
     }
     var prv = jQuery('div.preview');

--- a/style.css
+++ b/style.css
@@ -2,6 +2,9 @@ div#plugin_enforcesummary_wrapper {
     font-size: 85%;
     /* border: 1px solid #ccc; */
 }
+div#plugin_enforcesummary_wrapper ul {
+	margin: 2px 0 0 0;
+}
 div#plugin_enforcesummary_wrapper .li {
     color: #cc9999 !important;
 }


### PR DESCRIPTION
This PR will make the EnforceSummary plugin compatible with DokuWiki snapshot 2020-10-13 or later that [#3198](https://github.com/splitbrain/dokuwiki/pull/3198) merged. The edit form has now build using new **dokuwiki\Form\Form** class instead of deprecated **Doku_Form**.  We need new event **FORM_EDIT__OUTPUT** handler to modify the edit form.

Also, the id of minoredit checkbox has changed to "edit__minoredit" because  the id must contain two underscore "__" in the Form class. The jQuery selector for the checkbox needs to update to find both id, "#edit__minoredit" or "#minoredit".
 

 